### PR TITLE
update servo [2015-12-02]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,14 @@
 name = "miserve"
 version = "0.1.0"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.3.5 (git+https://github.com/tomaka/glutin)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo 0.0.1 (git+https://github.com/servo/servo)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -17,74 +17,82 @@ name = "advapi32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "android_glue"
-version = "0.0.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "angle"
 version = "0.1.0"
-source = "git+https://github.com/ecoal95/angle?branch=servo#77288884bd7a89bf3019ca94dcda6c94cb178aa4"
+source = "git+https://github.com/ecoal95/angle?branch=servo#2c14c35cdc223eb95efcaf6830d339db5b535d76"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "app_units"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aster"
-version = "0.4.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "azure"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#53e7b7d07bd43199b136d869b1605016ed882cbc"
+version = "0.2.0"
+source = "git+https://github.com/servo/rust-azure#5a5701c269cb7cb65f6c690122ef75c268f8d44d"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 0.1.0 (git+https://github.com/servo/core-text-rs)",
- "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "egl 0.2.0 (git+https://github.com/servo/rust-egl)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize_plugin 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bincode"
 version = "0.4.0"
-source = "git+https://github.com/TyOverby/bincode#5bc43b85bcd9290e9ffc519eca32913214c81124"
+source = "git+https://github.com/TyOverby/bincode#c1d94fe8590a91c1f5f163d7d3f23df2c84f0d21"
 dependencies = [
- "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -92,145 +100,192 @@ name = "block"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "brotli"
+version = "0.3.17"
+source = "git+https://github.com/ende76/brotli-rs#4a8c42cce771ded65fe64d6816f5d7303006b2ea"
+
+[[package]]
 name = "byteorder"
-version = "0.3.11"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1 (git+https://github.com/servo/servo)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1 (git+https://github.com/servo/servo)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
+
+[[package]]
+name = "caseless"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cgl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#8c4c31e73a5ac5afd97825acc4c534dccfc0ab9b"
+source = "git+https://github.com/aweinstock314/rust-clipboard#ef4cf77c9c736e0951df797ff4e1a7c945ce2e34"
 dependencies = [
- "clipboard-win 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc-foundation 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc_id 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clipboard-win 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc-foundation 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc_id 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clipboard-win"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clock_ticks"
-version = "0.0.6"
-source = "git+https://github.com/tomaka/clock_ticks#acfcf96806ae5e3bc647b7412a1c430ce62b79a1"
+version = "0.1.0"
+source = "git+https://github.com/tomaka/clock_ticks#d4b7f5d53d400ae47f20487ebbbf071c351ea40e"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cocoa"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cocoa"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "compositing"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "canvas 0.0.1 (git+https://github.com/servo/servo)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
  "clipboard 0.0.3 (git+https://github.com/aweinstock314/rust-clipboard)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 0.1.0 (git+https://github.com/servo/core-text-rs)",
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gaol 0.0.1 (git+https://github.com/pcwalton/gaol)",
  "gfx 0.0.1 (git+https://github.com/servo/servo)",
  "gfx_traits 0.0.1 (git+https://github.com/servo/servo)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout_traits 0.0.1 (git+https://github.com/servo/servo)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1 (git+https://github.com/servo/servo)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "cookie"
-version = "0.1.21"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -238,16 +293,42 @@ name = "core-foundation"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-graphics"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -256,19 +337,19 @@ version = "0.1.0"
 source = "git+https://github.com/servo/core-text-rs#d97cd4ae33509857f956e64c71f43cc71c98430f"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cssparser"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -287,37 +368,37 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
@@ -326,7 +407,7 @@ name = "dlib"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -334,7 +415,7 @@ name = "dwmapi-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -343,15 +424,15 @@ name = "dylib"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "egl"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-egl#b21a3eafc321bd498231fcd4f4704fd90898ebf4"
+version = "0.2.0"
+source = "git+https://github.com/servo/rust-egl#c59c59f6dc252e2ab17103b045d7ab1e452f32da"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -412,39 +493,52 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "enum_primitive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "euclid"
-version = "0.1.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize_plugin 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "expat-sys"
 version = "2.1.0"
-source = "git+https://github.com/servo/libexpat#b0f0d40b6651b0f6286f0f6bcc31c86c5c6c0f4f"
+source = "git+https://github.com/servo/libexpat#b4fdb7a2c9825bdeafcd32ac43560e31ca839649"
+dependencies = [
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "flate2"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -455,19 +549,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fontconfig"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-fontconfig#7839e5adcb4d6da3cefe2256f5071ac0203b9206"
+source = "git+https://github.com/servo/rust-fontconfig#5ad2ec0436036cd8151f7e03b637d89470daba91"
 dependencies = [
  "fontconfig-sys 2.11.1 (git+https://github.com/servo/libfontconfig)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fontconfig-sys"
 version = "2.11.1"
-source = "git+https://github.com/servo/libfontconfig#b01ee3e2f8523a6566b8e5d406a2176ccb574060"
+source = "git+https://github.com/servo/libfontconfig#3f93fab726d951a506fd318b359912b4bdcd2e35"
 dependencies = [
  "expat-sys 2.1.0 (git+https://github.com/servo/libexpat)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -475,13 +570,16 @@ name = "freetype"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-freetype#d564ff90a3c69d987f5c015d7ec034cfaee21aff"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "freetype-sys"
 version = "2.4.11"
-source = "git+https://github.com/servo/libfreetype2#8b6e4e384dd78a5b373c9bfcdd4a2f2cf650db86"
+source = "git+https://github.com/servo/libfreetype2#237f95bae7536bae7fcfbbc65dba7285f422b90f"
+dependencies = [
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futf"
@@ -493,12 +591,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gaol"
+version = "0.0.1"
+source = "git+https://github.com/pcwalton/gaol#71865ff8a1824cbc1cbee4d388d56c5ba1b5ffc2"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
-version = "0.3.12"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -506,132 +614,176 @@ name = "gdi32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "getopts"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "gfx"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 0.1.0 (git+https://github.com/servo/core-text-rs)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1 (git+https://github.com/servo/servo)",
- "harfbuzz 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1 (git+https://github.com/servo/servo)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "gfx_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+]
+
+[[package]]
+name = "gif"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_common"
-version = "0.0.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_generator"
-version = "0.0.26"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_generator"
-version = "0.0.27"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gleam"
-version = "0.1.9"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glutin"
+version = "0.4.2"
+source = "git+https://github.com/servo/glutin?branch=servo#f04bc869a37752d3d4a4258660428a360588e3a7"
+dependencies = [
+ "android_glue 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmesa-sys 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-kbd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-window 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glutin"
-version = "0.3.5"
-source = "git+https://github.com/tomaka/glutin#8092fd640938366110627027b3471025abd2c4b9"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "android_glue 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_glue 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-kbd 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-window 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-kbd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-window 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -639,26 +791,27 @@ name = "glx"
 version = "0.0.1"
 source = "git+https://github.com/servo/rust-glx#75ed2359f50c16c60f871e2f5f146e2016d8453d"
 dependencies = [
- "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "harfbuzz"
-version = "0.1.1"
+name = "harfbuzz-sys"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hbs-common-sys"
 version = "0.1.0"
-source = "git+https://github.com/libheartbeats/heartbeats-simple-sys.git#2b415b92cd955e63c4b939b91a3e7dbf5902c8af"
+source = "git+https://github.com/libheartbeats/heartbeats-simple-sys.git#5ce01d0e943d4d81e5c84401f85c892e47825415"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,16 +820,16 @@ version = "0.1.0"
 source = "git+https://github.com/libheartbeats/heartbeats-simple-rust.git#70ad49c810da3842e12eef2075d58552f1f6c707"
 dependencies = [
  "hbs-pow-sys 0.1.0 (git+https://github.com/libheartbeats/heartbeats-simple-sys.git)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hbs-pow-sys"
 version = "0.1.0"
-source = "git+https://github.com/libheartbeats/heartbeats-simple-sys.git#2b415b92cd955e63c4b939b91a3e7dbf5902c8af"
+source = "git+https://github.com/libheartbeats/heartbeats-simple-sys.git#5ce01d0e943d4d81e5c84401f85c892e47825415"
 dependencies = [
  "hbs-common-sys 0.1.0 (git+https://github.com/libheartbeats/heartbeats-simple-sys.git)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -685,167 +838,188 @@ name = "heapsize"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "heapsize_plugin"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hpack"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "html5ever"
-version = "0.2.3"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "html5ever_macros 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendril 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "html5ever_macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "httparse"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.6.13"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-tags 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "solicit 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "io-surface"
+name = "image"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inflate"
 version = "0.1.0"
-source = "git+https://github.com/servo/io-surface-rs#55ed8f9491e6d1f67b60ed2683088a4c5da058f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "io-surface"
+version = "0.1.1"
+source = "git+https://github.com/servo/io-surface-rs#aaaa5da1f2d75958fc1a3a06648717be4ea08283"
 dependencies = [
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#63a7b00deb5296ff890cc2c7964e039dbd7aeb13"
+source = "git+https://github.com/servo/ipc-channel#8306cdf03008bc32cd3196e1823661b0c773ffd3"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
- "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "js"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#ff77d7152515b8dbfe29cb5f883e3a348673741c"
+version = "0.1.1"
+source = "git+https://github.com/servo/rust-mozjs#d712414c8b1cab4672d88ec0f4861c9768ea27d7"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozjs_sys 0.0.0 (git+https://github.com/servo/mozjs)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kernel32-sys"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "khronos_api"
-version = "0.0.7"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "khronos_api"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "language-tags"
-version = "0.0.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#a8400005fd3ee37ced92865184974c9a93201bc0"
+source = "git+https://github.com/servo/rust-layers#82672814604f5e4293fcc9d2f89055a85ad87c11"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "egl 0.2.0 (git+https://github.com/servo/rust-egl)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "glx 0.0.1 (git+https://github.com/servo/rust-glx)",
- "io-surface 0.1.0 (git+https://github.com/servo/io-surface-rs)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.1.1 (git+https://github.com/servo/io-surface-rs)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "layout"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1 (git+https://github.com/servo/servo)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
- "clock_ticks 0.0.6 (git+https://github.com/tomaka/clock_ticks)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock_ticks 0.1.0 (git+https://github.com/tomaka/clock_ticks)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1 (git+https://github.com/servo/servo)",
  "gfx_traits 0.0.1 (git+https://github.com/servo/servo)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layout_traits 0.0.1 (git+https://github.com/servo/servo)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
@@ -853,45 +1027,51 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1 (git+https://github.com/servo/servo)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
- "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1 (git+https://github.com/servo/servo)",
- "unicode-bidi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "style_traits 0.0.1 (git+https://github.com/servo/servo)",
+ "unicode-bidi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "layout_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1 (git+https://github.com/servo/servo)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -903,12 +1083,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.3.1"
+name = "libz-sys"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "log"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lzw"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mac"
@@ -920,7 +1115,7 @@ name = "malloc_buf"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -930,10 +1125,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -941,16 +1136,24 @@ name = "mime"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime_guess"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miniz-sys"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -958,82 +1161,97 @@ name = "mmap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#5da854e637fcfeefe4aebda0b66fc2406ea7dc63"
+source = "git+https://github.com/servo/mozjs#10796a16f6a8aba1e4990a0939b8b2f4a1075e55"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "msg"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "io-surface 0.1.0 (git+https://github.com/servo/io-surface-rs)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.1.1 (git+https://github.com/servo/io-surface-rs)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1 (git+https://github.com/servo/servo)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "cookie 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "brotli 0.3.17 (git+https://github.com/ende76/brotli-rs)",
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
- "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
- "uuid 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_image 0.2.0 (git+https://github.com/servo/rust-stb-image)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
@@ -1042,85 +1260,97 @@ name = "num"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "objc"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_buf 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "objc-foundation"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc_id 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc_id 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "objc_id"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "offscreen_gl_context"
 version = "0.1.0"
-source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#41fb6bf5a8ff16024e62ec71892bfe7697de3b7d"
+source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#922819338946a3fa26a8ae49dc34cc1ede8b3705"
 dependencies = [
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.4.2 (git+https://github.com/servo/glutin?branch=servo)",
+ "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys-extras"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1128,40 +1358,40 @@ name = "osmesa-sys"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug-builders 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_generator 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1172,9 +1402,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "plugins"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "tenacious 0.0.9 (git+https://github.com/servo/rust-tenacious)",
+ "tenacious 0.0.14 (git+https://github.com/Manishearth/rust-tenacious)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1187,68 +1418,64 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-png#a3569ca11ea54e5d6152ee80d7d39b2799700dbf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "png-sys 1.6.16 (git+https://github.com/servo/rust-png)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "png-sys"
-version = "1.6.16"
-source = "git+https://github.com/servo/rust-png#a3569ca11ea54e5d6152ee80d7d39b2799700dbf"
 
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
  "hbs-pow 0.1.0 (git+https://github.com/libheartbeats/heartbeats-simple-rust.git)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_info 0.0.1 (git+https://github.com/servo/servo)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quasi"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quasi_codegen"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quasi_macros"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quasi_codegen 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1262,12 +1489,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1280,23 +1507,15 @@ name = "regex"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "regex_macros"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "rustc-serialize"
@@ -1306,83 +1525,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
  "angle 0.1.0 (git+https://github.com/ecoal95/angle?branch=servo)",
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1 (git+https://github.com/servo/servo)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "caseless 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "html5ever 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "js 0.1.1 (git+https://github.com/servo/rust-mozjs)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
- "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1 (git+https://github.com/servo/servo)",
- "tendril 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "style_traits 0.0.1 (git+https://github.com/servo/servo)",
+ "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
- "uuid 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "websocket 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.1.0 (git+https://github.com/Ygg01/xml5ever)",
 ]
 
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
+ "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "selectors"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#572353b3209af040cd3e6261978b09c7f8122844"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1390,12 +1615,12 @@ dependencies = [
 
 [[package]]
 name = "serde_codegen"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_macros 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1404,56 +1629,59 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "servo"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1 (git+https://github.com/servo/servo)",
  "canvas_traits 0.0.1 (git+https://github.com/servo/servo)",
  "compositing 0.0.1 (git+https://github.com/servo/servo)",
  "devtools 0.0.1 (git+https://github.com/servo/servo)",
  "devtools_traits 0.0.1 (git+https://github.com/servo/servo)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gaol 0.0.1 (git+https://github.com/pcwalton/gaol)",
  "gfx 0.0.1 (git+https://github.com/servo/servo)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1 (git+https://github.com/servo/servo)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1 (git+https://github.com/servo/servo)",
  "net 0.0.1 (git+https://github.com/servo/servo)",
  "net_traits 0.0.1 (git+https://github.com/servo/servo)",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "profile 0.0.1 (git+https://github.com/servo/servo)",
  "profile_traits 0.0.1 (git+https://github.com/servo/servo)",
  "script 0.0.1 (git+https://github.com/servo/servo)",
  "script_traits 0.0.1 (git+https://github.com/servo/servo)",
  "style 0.0.1 (git+https://github.com/servo/servo)",
- "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "shared_library"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1461,25 +1689,31 @@ name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "simd"
+version = "0.1.0"
+source = "git+https://github.com/huonw/simd#c4403387adb9a25188ff00ddc82582c2e1017030"
+
+[[package]]
 name = "skia"
 version = "0.0.20130412"
-source = "git+https://github.com/servo/skia#fce887de8bd7e3144226b3c48f088c1395a3b328"
+source = "git+https://github.com/servo/skia#a3102fc074612c9f44fb1b402fa1885bba25f233"
 dependencies = [
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "egl 0.2.0 (git+https://github.com/servo/rust-egl)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "expat-sys 2.1.0 (git+https://github.com/servo/libexpat)",
+ "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
- "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "glx 0.0.1 (git+https://github.com/servo/rust-glx)",
- "io-surface 0.1.0 (git+https://github.com/servo/io-surface-rs)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.1.1 (git+https://github.com/servo/io-surface-rs)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1489,104 +1723,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "solicit"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stb_image"
-version = "0.1.0"
-source = "git+https://github.com/servo/rust-stb-image#ad05c642b64a9059dd31c37b1a1ac78722821008"
+version = "0.2.0"
+source = "git+https://github.com/servo/rust-stb-image#bf1edc24753962e474cae3a2ad376a6d423cd91d"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "string_cache"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_shared 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "string_cache_plugin"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_shared 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "string_cache_shared"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1 (git+https://github.com/servo/servo)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1 (git+https://github.com/servo/servo)",
 ]
 
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1594,28 +1809,28 @@ name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tempfile"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tenacious"
-version = "0.0.9"
-source = "git+https://github.com/servo/rust-tenacious#a04fe4a6e6c332f94b491b9369b8e50e94b3c37d"
+version = "0.0.14"
+source = "git+https://github.com/Manishearth/rust-tenacious#7e1729efe79ac8427dac322bfc936dbdb1f36d10"
 
 [[package]]
 name = "tendril"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1625,12 +1840,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1645,15 +1860,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicase"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-script"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1666,61 +1894,64 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "0.2.37"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "user32-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "util"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo#0d37e8f96b7f40d14bf4fbb0b66e42a01302a336"
+source = "git+https://github.com/servo/servo#2be60be062e14c937af601faed78a6aceccdb062"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "html5ever 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "js 0.1.1 (git+https://github.com/servo/rust-mozjs)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1 (git+https://github.com/servo/servo)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uuid"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1734,52 +1965,53 @@ name = "wayland-client"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-kbd"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-window"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "websocket"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1788,21 +2020,30 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "x11"
-version = "2.0.1"
+name = "ws2_32-sys"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "x11"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "x11-dl"
-version = "2.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1810,6 +2051,30 @@ name = "xml-rs"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.1.0"
+source = "git+https://github.com/Ygg01/xml5ever#9da3b1628bfcb69a48420f7aef69739d6706aa6a"
+dependencies = [
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ time       = "0.1.12"
 num_cpus   = "*"
 
 # windowing dependencies
-glutin = { git = "https://github.com/tomaka/glutin" }
+glutin = "*"
 x11    = "2.0"
 
 [dependencies.servo]

--- a/src/browser/browser.rs
+++ b/src/browser/browser.rs
@@ -24,8 +24,8 @@ use browser::{buffer, Buffer, Tab, Event};
 
 /// This struct is the main entry point of the browser.
 ///
-/// When rendering it will render the tab bar, the input bar and the curren tab to
-/// the given textures, and composite them back onto the screen.
+/// When rendering it will render the tab bar, the input bar and the current tab
+/// to the given textures, and composite them back onto the screen.
 pub struct Browser {
 	window: Rc<glutin::Window>,
 	events: Rc<RefCell<Vec<Event>>>,

--- a/src/browser/browser.rs
+++ b/src/browser/browser.rs
@@ -75,7 +75,7 @@ impl Browser {
 		let opts     = opts::get();
 		let resource = new_resource_task(opts.user_agent.clone(), None);
 
-		gl::load_with(|s| window.get_proc_address(s));
+		gl::load_with(|s| window.get_proc_address(s) as *const _);
 		
 		Browser {
 			window: window,

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -16,6 +16,7 @@ use servo::euclid::scale_factor::ScaleFactor;
 use servo::util::cursor::Cursor;
 
 use servo::compositing::Constellation;
+use servo::compositing::constellation::InitialConstellationState;
 use servo::compositing::CompositorTask;
 use servo::layout::layout_task::LayoutTask;
 use servo::script::script_task::ScriptTask;
@@ -45,11 +46,17 @@ impl Buffer {
 		let mem_profiler  = browser.profiler().mem();
 
 		let constellation = Constellation::<LayoutTask, ScriptTask>::start(
-			proxy.clone_compositor_proxy(),
-			browser.resource(),
-			browser.cache().image(), browser.cache().font(),
-			time_profiler.clone(), mem_profiler.clone(), None,
-			browser.storage(), true);
+			InitialConstellationState {
+				compositor_proxy:   proxy.clone_compositor_proxy(),
+				resource_task:      browser.resource(),
+				image_cache_task:   browser.cache().image(),
+				font_cache_task:    browser.cache().font(),
+				time_profiler_chan: time_profiler.clone(),
+				mem_profiler_chan:  mem_profiler.clone(),
+				devtools_chan:      None,
+				storage_task:       browser.storage(),
+				supports_clipboard: true
+			});
 
 		let mut compositor = CompositorTask::create(Some(window.clone()), proxy, receiver,
 			constellation, time_profiler, mem_profiler);

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -18,6 +18,7 @@ use servo::util::cursor::Cursor;
 use servo::compositing::Constellation;
 use servo::compositing::constellation::InitialConstellationState;
 use servo::compositing::CompositorTask;
+use servo::compositing::compositor_task::InitialCompositorState;
 use servo::layout::layout_task::LayoutTask;
 use servo::script::script_task::ScriptTask;
 
@@ -56,10 +57,19 @@ impl Buffer {
 				devtools_chan:      None,
 				storage_task:       browser.storage(),
 				supports_clipboard: true
-			});
+			}
+		);
 
-		let mut compositor = CompositorTask::create(Some(window.clone()), proxy, receiver,
-			constellation, time_profiler, mem_profiler);
+		let mut compositor = CompositorTask::create(
+			Some(window.clone()),
+			InitialCompositorState{
+				sender:             proxy,
+				receiver:           receiver,
+				constellation_chan: constellation,
+				time_profiler_chan: time_profiler,
+				mem_profiler_chan:  mem_profiler
+			}
+		);
 
 		compositor.handle_events(vec![WindowEvent::InitializeCompositing]);
 

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -127,12 +127,6 @@ impl fmt::Debug for Buffer {
 	}
 }
 
-impl Drop for Buffer {
-	fn drop(&mut self) {
-		self.compositor.shutdown();
-	}
-}
-
 struct Window {
 	glutin: Rc<glutin::Window>,
 	buffer: RefCell<Option<Rc<RefCell<Buffer>>>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
 	unsafe {
 		window.make_current().expect("failed to make the context current");
 
-		gl::load_with(|s| window.get_proc_address(s));
+		gl::load_with(|s| window.get_proc_address(s) as *const _);
 
 		gl::clear_color(0.6, 0.6, 0.6, 1.0);
 		gl::clear(gl::COLOR_BUFFER_BIT);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax, result_expect)]
+#![feature(box_syntax)]
 #![allow(dead_code, unused_variables)]
 
 extern crate servo;
@@ -24,6 +24,7 @@ extern crate num_cpus;
 use std::env;
 use std::rc::Rc;
 use std::thread;
+use std::time::Duration;
 
 pub mod util;
 use util::init;
@@ -72,7 +73,7 @@ fn main() {
 		}
 		else {
 			browser.handle(browser::Event::Idle);
-			thread::sleep_ms(10);
+			thread::sleep(Duration::from_millis(10));
 		}
 	}
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use servo::util::opts;
+use servo::util::{opts, resource_files};
 use servo::net_traits::hosts;
 use servo::script::dom::bindings::codegen::RegisterBindings;
 use servo::script;
@@ -17,8 +17,8 @@ pub fn init() {
 	opts.user_agent = concat!("Mozilla/5.0 Servo/1.0 miserve/",
 		env!("CARGO_PKG_VERSION")).to_owned();
 
-	opts.url            = None;
-	opts.resources_path = None;
+	opts.url = None;
+	resource_files::set_resources_path(None);
 
 	opts.headless  = false;
 	opts.hard_fail = false;


### PR DESCRIPTION
1. Obviously don't merge, this does not build.
2. Don't know any rust -> **don't know what I'm doing**.
3. Will squash commits if you want. Put multiple for now because I think it's easier to review?
4. The error I told you about yesterday (http://pastebin.com/h1DSY85L) seems to have been fixed before I could track it down, so now cargo actually gets to the compilation stage.
5. I changed the source for `glutin` in Cargo.toml to just `"*"` because I guess the `{ git = ... }` was there because glutin wasn't a crate at that time?
6. Of course, feel free to disregard this pr entirely and/or otherwise fix the remaining errors yourself if you already know how!

After getting the latest Cargo.lock from servo/servo/components/servo/Cargo.lock, the `cargo build` error is:

```
src/util.rs:21:2: 21:21 error: attempted access of field `resources_path` on type `util::opts::Opts`, but no field with that name was found
src/util.rs:21  opts.resources_path = None;
                ^~~~~~~~~~~~~~~~~~~
src/util.rs:21:7: 21:21 help: did you mean `userscripts`?
src/util.rs:21  opts.resources_path = None;
                     ^~~~~~~~~~~~~~
src/browser/browser.rs:78:21: 78:47 error: mismatched types:
 expected `*const libc::c_void`,
    found `*const ()`
(expected enum `libc::c_void`,
    found ()) [E0308]
src/browser/browser.rs:78       gl::load_with(|s| window.get_proc_address(s));
                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/browser/browser.rs:78:21: 78:47 help: run `rustc --explain E0308` to see a detailed explanation
src/browser/buffer.rs:47:23: 52:28 error: this function takes 1 parameter but 9 parameters were supplied [E0061]
src/browser/buffer.rs:47        let constellation = Constellation::<LayoutTask, ScriptTask>::start(
src/browser/buffer.rs:48            proxy.clone_compositor_proxy(),
src/browser/buffer.rs:49            browser.resource(),
src/browser/buffer.rs:50            browser.cache().image(), browser.cache().font(),
src/browser/buffer.rs:51            time_profiler.clone(), mem_profiler.clone(), None,
src/browser/buffer.rs:52            browser.storage(), true);
src/browser/buffer.rs:47:23: 52:28 help: run `rustc --explain E0061` to see a detailed explanation
src/browser/buffer.rs:54:24: 55:47 error: this function takes 2 parameters but 6 parameters were supplied [E0061]
src/browser/buffer.rs:54        let mut compositor = CompositorTask::create(Some(window.clone()), proxy, receiver,
src/browser/buffer.rs:55            constellation, time_profiler, mem_profiler);
src/browser/buffer.rs:54:24: 55:47 help: run `rustc --explain E0061` to see a detailed explanation
src/browser/buffer.rs:115:19: 115:29 error: no method named `shutdown` found for type `Box<compositing::compositor_task::CompositorEventListener + 'static>` in the current scope
src/browser/buffer.rs:115       self.compositor.shutdown();
                                                ^~~~~~~~~~
src/main.rs:48:21: 48:47 error: mismatched types:
 expected `*const libc::c_void`,
    found `*const ()`
(expected enum `libc::c_void`,
    found ()) [E0308]
src/main.rs:48      gl::load_with(|s| window.get_proc_address(s));
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.rs:48:21: 48:47 help: run `rustc --explain E0308` to see a detailed explanation
error: aborting due to 6 previous errors
Could not compile `miserve`.
```

(All the dependencies build fine, with rustc `1805bba399805d8fd8e85e23c31a0580f21533cb`.)

I've only fixed the first one (I think!), and now I'm already stuck on the 5th error. -_- The `shutdown` method was removed in https://github.com/servo/servo/pull/7913. As you can see in that diff, it seems to have been replaced with the `start/finish_shutting_down` functions, but I'm not sure how to use/access them. Because even though they have `pub`, it doesn't look like the `compositor` module has been made publicly accessible: https://github.com/servo/servo/blob/2be60be062e14c937af601faed78a6aceccdb062/components/compositing/lib.rs#L58 ?

I'm guessing this is probably just down to my lack of knowledge about rust right now..., hence why I've decided to open this prematurely. I would have preferred to have fixed everything and have it all working before opening, but I realised that's harder than I expected... so opening a wip pr might make it a little easier, if you or others can find time. Speaking of which, no rush, it's (close to?) holiday season.
